### PR TITLE
Link to latest android docs instead of a specific version

### DIFF
--- a/docs/overview.md
+++ b/docs/overview.md
@@ -55,7 +55,7 @@ Users of the Proximity Kit client library agree to abide by the license terms as
 ## Additional Resources
 
 <a class="btn" href="android/getting-started">Getting Started</a>
-<a class="btn" href="http://developer.radiusnetworks.com/proximitykit/android/docs/0.4.0/">SDK Reference</a>
+<a class="btn" href="http://developer.radiusnetworks.com/proximitykit/android/docs/latest">SDK Reference</a>
 <a class="btn" href="https://github.com/RadiusNetworks/proximitykit-reference-android">Android Studio Reference App</a>
 
 <a class="btn" href="https://altbeacon.github.io/android-beacon-library/javadoc/index.html">Android Beacon Library Documentation</a>


### PR DESCRIPTION
Now we only have four repos to update for each PK Android release instead of five!