### PR TITLE
Add Urban Airship Technote

### DIFF
--- a/docs/ios/urban-airship/RPKAirshipAdapter.h
+++ b/docs/ios/urban-airship/RPKAirshipAdapter.h
@@ -1,0 +1,20 @@
+// RPKAirshipAdapter
+//
+// Reference class for implmenting Urban Airship Integration with Proximity Kit
+//
+// This class can be added to an iOS all to integrate beacon presense using the
+// exisitng Proximity Kit configuration with the Urban Airship SDK. This will
+// subscribe to NSNotifications broadcast by ProximityKit.
+//
+// Usage:
+//
+//     RPKAirshipAdapter *pkAdapter = RPKAirshipAdapter;
+//     [pkAdapter start];
+//
+@interface RPKAirshipAdapter : NSObject
+@property UAirship* airship;
+
+-(void) start;
+-(void) stop;
+
+@end

--- a/docs/ios/urban-airship/RPKAirshipAdapter.m
+++ b/docs/ios/urban-airship/RPKAirshipAdapter.m
@@ -1,0 +1,144 @@
+#import "RPKAirshipAdapter.h"
+#import "RPKManager.h"
+@import AirshipKit;
+
+@implementation RPKAirshipAdapter
+
+# pragma mark Constructor and Destructor
+
+- (id)init {
+  if (self = [super init]) {
+    self.airship = [UAirship shared];
+  }
+  return self;
+}
+
+- (void)dealloc {
+  [self stop];
+}
+
+#pragma mark Start and Stop the observers
+
+-(void) start {
+  [self registerForPKNotifications];
+}
+-(void) stop {
+  [self unregisterForPKNotifications];
+}
+
+#pragma mark Notifications
+
+
+- (void)registerForPKNotifications {
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(didEnterRegion:)
+                                               name:RPKManagerDidEnterRegionNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(didExitRegion:)
+                                               name:RPKManagerDidExitRegionNotification
+                                             object:nil];
+  [[NSNotificationCenter defaultCenter] addObserver:self
+                                           selector:@selector(didDetermineStateForRegion:)
+                                               name:RPKManagerDidDetermineStateForRegionNotification
+                                             object:nil];
+}
+
+- (void)unregisterForPKNotifications {
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:RPKManagerDidEnterRegionNotification
+                                                object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:RPKManagerDidExitRegionNotification
+                                                object:nil];
+  [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                  name:RPKManagerDidDetermineStateForRegionNotification
+                                                object:nil];
+}
+
+- (void)didEnterRegion:(NSNotification *)notification {
+  RPKRegion *region = notification.userInfo[RPKManagerNotificationRegionKey];
+  [self addTags:region];
+}
+
+- (void)didExitRegion:(NSNotification *)notification {
+  RPKRegion *region = notification.userInfo[RPKManagerNotificationRegionKey];
+  [self removeTags:region];
+}
+
+- (void)didDetermineStateForRegion:(NSNotification *)notification {
+  RPKRegion *region = notification.userInfo[RPKManagerNotificationRegionKey];
+  CLRegionState state = [notification.userInfo[RPKManagerNotificationRegionStateKey] integerValue];
+
+  if (state == RPKRegionStateInside) {
+    [self addTags:region];
+    [self addPersistentTags:region];
+    [self addEvent:region];
+  } else if (state == RPKRegionStateOutside) {
+    [self removeTags:region];
+  } else if (state == RPKRegionStateUnknown) {
+    [self removeTags:region];
+  }
+}
+
+#pragma mark Publish Tags Airship
+
+- (void)addTags:(RPKRegion *)region {
+  NSArray *tags = [self getTags:region];
+  if ([tags count] > 0) {
+    [self.airship addTags:tags];
+  }
+}
+
+- (void)removeTags:(RPKRegion *)region {
+  NSArray *tags = [self getTags:region];
+  if ([tags count] > 0) {
+    [self.airship removeTags:tags];
+  }
+}
+
+- (void)addPersistentTags:(RPKRegion *)region {
+  NSArray *tags = [self getPersistentTags:region];
+  if ([tags count] > 0) {
+    [self.airship addTags:tags];
+  }
+}
+
+- (void)addEvent:(RPKRegion *)region {
+  NSString *event = [self getEvent:region];
+  if (event) {
+    [self.airship addEvent:event];
+  }
+}
+
+#pragma mark UA Tag Metadata
+
+- (NSArray *)getTags:(RPKRegion *)region {
+  NSMutableArray *tags = [[NSMutableArray alloc] init];
+
+  NSString *uaTagStr = region.attributes[@"ua_tags"];
+  if (uaTagStr) {
+    for (NSString *tag in [uaTagStr componentsSeparatedByString:@","]) {
+      [tags addObject:[tag stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+    }
+  }
+  return tags;
+}
+
+- (NSArray *)getPersistentTags:(RPKRegion *)region {
+  NSMutableArray *tags = [[NSMutableArray alloc] init];
+
+  NSString *uaTagStr = region.attributes[@"ua_persistent_tags"];
+  if (uaTagStr) {
+    for (NSString *tag in [uaTagStr componentsSeparatedByString:@","]) {
+      [tags addObject:[tag stringByTrimmingCharactersInSet: [NSCharacterSet whitespaceAndNewlineCharacterSet]]];
+    }
+  }
+  return tags;
+}
+
+- (NSString *)getEvent:(RPKRegion *)region {
+  return region.attributes[@"ua_event"];
+}
+
+@end

--- a/docs/urban-airship.md
+++ b/docs/urban-airship.md
@@ -8,13 +8,16 @@ Note: This functionality is currently iOS only. Android support coming soon, if 
 
 # Enable Integration in your App
 
-To enable integration in the SDK, you will need to set the Urban Airship manager on the Proximity Kit manager. This is a simple one-liner:
+To enable integration in the SDK, you will need to add the reference code provided in our `RPKAirshipAdapter` class, and start that up. This class will listen to NSNotifications broadcast by the `RPKManager`.
 
 ```objc
-[self.pkManager setAirship: [UAirship shared]];
+RPKAirshipAdapter *pkAdapter = RPKAirshipAdapter;
+[pkAdapter start];
 ```
 
-That's it. Now the Proximity Kit SDK will look for the meta data attributes and handle the rest of the integration on the actual device. Now all you need to do is set tags or events.
+The source for this reference is avaliable [here](ios/urban-airship/).
+
+Now the Proximity Kit/Urban Airship Adapter will listen for the meta data attributes and handle the rest of the integration on the actual device. Now all you need to do is set tags or events.
 
 # Tags
 


### PR DESCRIPTION
Adds the reference class and short instructions to integrating Urban Airship with Proximity Kit.

1. Copy reference class into app.
2. Add a few lines of code:

    ```
    RPKAirshipAdapter *pkAdapter = RPKAirshipAdapter;
    [pkAdapter start];
    ```